### PR TITLE
Two small suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ pip3 install -r requirements.txt
 ```
 
 ## Usage
-`sudo python3 desktop-creator.py https://reddit.com Reddit`
+`python3 desktop-creator.py https://reddit.com Reddit`
 
 ## Credits
 Most of the credit for this project should go to https://github.com/phillipsm

--- a/desktop-creator.py
+++ b/desktop-creator.py
@@ -15,6 +15,9 @@ url = sys.argv[1]
 
 name = sys.argv[2]
 
+# If this is the first run we need to create the images directory
+os.system("mkdir -p images/")
+
 # Make a request to the webpage to find the icon
 favicon_url = pyfav_utils.get_favicon_url(url)
 


### PR DESCRIPTION
First suggestion fixes an error I encountered running desktop-creator right out of the box - if the images/ subdirectory doesn't exist it will throw an error. This addition creates the  directory if it's not present.

The second suggestion is in the usage example - sudo is not needed (and in fact creates an error for me when I tried it).

Thanks for the useful script! I may keep working on it if that's OK. :)

Cheers,

Dave