### PR TITLE
Added ability to specify which browser link should open in

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ pip3 install -r requirements.txt
 ## Usage
 `python3 desktop-creator.py https://reddit.com Reddit`
 
+## To specify that link should open in particular browser (optional; otherwise link will open in system default browser):
+'python3 desktop-creator.py https://netflix.com Netflix google-chrome'
+
 ## Credits
 Most of the credit for this project should go to https://github.com/phillipsm
 who wrote the scripts for the favicon downloading as part of

--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ pip3 install -r requirements.txt
 ## Usage
 `python3 desktop-creator.py https://reddit.com Reddit`
 
-## To specify that link should open in particular browser (optional; otherwise link will open in system default browser):
-'python3 desktop-creator.py https://netflix.com Netflix google-chrome'
+## Specify Browser 
+Optionally, you may specify which browser the link should open in.
+
+`python3 desktop-creator.py https://netflix.com Netflix google-chrome`
 
 ## Credits
 Most of the credit for this project should go to https://github.com/phillipsm

--- a/desktop-creator.py
+++ b/desktop-creator.py
@@ -15,6 +15,12 @@ url = sys.argv[1]
 
 name = sys.argv[2]
 
+# Catch optional third argument
+try:
+    app = sys.argv[3]         
+except:
+    app = "xdg-open"
+
 # If this is the first run we need to create the images directory
 os.system("mkdir -p images/")
 
@@ -44,12 +50,12 @@ desktop_template = '''
 Name={0}
 Type=Application
 Icon={1}
-Exec=xdg-open {2}
+Exec={3} {2}
 '''
 
 icon_path = "{0}/{1}".format(filepath, path)
 
-final_template = desktop_template.format(site_name, icon_path, url)
+final_template = desktop_template.format(site_name, icon_path, url, app)
 print (final_template)
 
 application_dir = os.path.expanduser("~/.local/share/applications")


### PR DESCRIPTION
One more suggestion :)

I thought it would be useful to be able to specify which browser the link opens in. For example, I normally use Firefox, but find certain sites (eg Netflix) just work better in Chrome. With this addition you can now specify which browser you want to use to open the link. It is optional; not specifying a browser will use the default browser (ie, the current behaviour).